### PR TITLE
Some fixes for Magic Keyboard 2 

### DIFF
--- a/MacKeyboard.ahk
+++ b/MacKeyboard.ahk
@@ -67,6 +67,8 @@ F19::Run https://facebook.com
 !+Left::SendInput ^+{Left}
 !+Right::SendInput ^+{Right}
 
+;Cmd-Backspace to Del
+#Backspace::Delete
 
 ; Make Ctrl + S work with cmd (windows) key
 #s::^s
@@ -79,7 +81,7 @@ F19::Run https://facebook.com
 
 ; Pasting
 #v::Send ^v
- 
+
 ; Cutting
 #x::^x
 

--- a/MacKeyboard.ahk
+++ b/MacKeyboard.ahk
@@ -47,11 +47,9 @@ F17::Run http://tumblr.com
 F18::Run http://www.reddit.com
 F19::Run https://facebook.com
 
-; Swap < and 
+; Some keyboards have the keys "\" and "<" swapped (at least with the italian layout). Swap them.
 \::<
-+\::+<
 <::\
-+<::+\
 
 ; --------------------------------------------------------------
 ; OS X system shortcuts

--- a/MacKeyboard.ahk
+++ b/MacKeyboard.ahk
@@ -79,7 +79,7 @@ F19::Run https://facebook.com
 
 ; Pasting
 #v::Send ^v
-
+ 
 ; Cutting
 #x::^x
 

--- a/MacKeyboard.ahk
+++ b/MacKeyboard.ahk
@@ -26,8 +26,8 @@ RAlt & F7::SendInput {Media_Prev}
 RAlt & F8::SendInput {Media_Play_Pause}
 RAlt & F9::SendInput {Media_Next}
 F10::SendInput {Volume_Mute}
-F11::SendInput {Volume_Down}
-F12::SendInput {Volume_Up}
+F11::SendInput {Volume_Down 2}
+F12::SendInput {Volume_Up 2}
 
 ; swap left command/windows key with left alt
 ;LWin::LAlt
@@ -47,9 +47,26 @@ F17::Run http://tumblr.com
 F18::Run http://www.reddit.com
 F19::Run https://facebook.com
 
+; Swap < and 
+\::<
++\::+<
+<::\
++<::+\
+
 ; --------------------------------------------------------------
 ; OS X system shortcuts
 ; --------------------------------------------------------------
+
+; cmd + arrows - start & end of lines, with shift for selecting text
+#Left::SendInput {Home}
+#Right::SendInput {End}
+#+Left::sendInput +{Home}
+#+Right::SendInput +{End}
+!Left::SendInput ^{Left}
+!Right::SendInput ^{Right}
+!+Left::SendInput ^+{Left}
+!+Right::SendInput ^+{Right}
+
 
 ; Make Ctrl + S work with cmd (windows) key
 #s::^s
@@ -58,10 +75,10 @@ F19::Run https://facebook.com
 #a::^a
 
 ; Copying
-#c::^c
+#c::Send ^c
 
 ; Pasting
-#v::^v
+#v::Send ^v
 
 ; Cutting
 #x::^x
@@ -145,7 +162,6 @@ Lwin & Tab::AltTab
 
 ; Map Alt + 3 to #
 !3::SendInput {#}
-
 
 
 ; --------------------------------------------------------------

--- a/MacKeyboard.ahk
+++ b/MacKeyboard.ahk
@@ -26,8 +26,8 @@ RAlt & F7::SendInput {Media_Prev}
 RAlt & F8::SendInput {Media_Play_Pause}
 RAlt & F9::SendInput {Media_Next}
 F10::SendInput {Volume_Mute}
-F11::SendInput {Volume_Down 2}
-F12::SendInput {Volume_Up 2}
+F11::SendInput {Volume_Down}
+F12::SendInput {Volume_Up}
 
 ; swap left command/windows key with left alt
 ;LWin::LAlt


### PR DESCRIPTION
I've fixed some issues using my Magic Keyboard 2 with Italian Layout.
My cmd-c and cmd-v combinations were ignored, a `Send` was added in those lines.
Multimedia keys still won't work (Volume settings not working, music control work only inside iTunes as far as I've tested).